### PR TITLE
Fix async workflow iteration

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -199,32 +199,44 @@ export class WorkflowCommonWorkspaceService {
       withDeleted: true,
     });
 
-    workflowVersions.forEach((workflowVersion) => {
-      workflowVersion.steps?.forEach(async (step) => {
-        if (step.type === WorkflowActionType.CODE) {
-          switch (operation) {
-            case 'delete':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
+    const promises: Promise<unknown>[] = [];
+
+    for (const workflowVersion of workflowVersions) {
+      for (const step of workflowVersion.steps ?? []) {
+        if (step.type !== WorkflowActionType.CODE) {
+          continue;
+        }
+
+        switch (operation) {
+          case 'delete':
+            promises.push(
+              this.serverlessFunctionService.deleteOneServerlessFunction({
                 id: step.settings.input.serverlessFunctionId,
                 workspaceId,
                 softDelete: true,
-              });
-              break;
-            case 'restore':
-              await this.serverlessFunctionService.restoreOneServerlessFunction(
+              }),
+            );
+            break;
+          case 'restore':
+            promises.push(
+              this.serverlessFunctionService.restoreOneServerlessFunction(
                 step.settings.input.serverlessFunctionId,
-              );
-              break;
-            case 'destroy':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
+              ),
+            );
+            break;
+          case 'destroy':
+            promises.push(
+              this.serverlessFunctionService.deleteOneServerlessFunction({
                 id: step.settings.input.serverlessFunctionId,
                 workspaceId,
                 softDelete: false,
-              });
-              break;
-          }
+              }),
+            );
+            break;
         }
-      });
-    });
+      }
+    }
+
+    await Promise.all(promises);
   }
 }


### PR DESCRIPTION
## Summary
- fix missing awaits on serverless function operations

## Testing
- `npx nx test twenty-server --skip-nx-cache` *(fails: 403 Forbidden)*
- `npx nx lint twenty-server` *(fails: 403 Forbidden)*
- `npx tsc -p packages/twenty-server/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68446cc5652c832fa0b918925b113402