### PR TITLE
Add lead scoring module

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Below are a few features we have implemented to date:
 + [Create one or several opportunities for each company](#create-one-or-several-opportunities-for-each-company)
 + [See rich notes tasks displayed in a timeline](#see-rich-notes-tasks-displayed-in-a-timeline)
 + [Create tasks on records](#create-tasks-on-records)
++ [AI-driven lead scoring & insights](#ai-driven-lead-scoring--insights)
 + [Navigate quickly through the app using keyboard shortcuts and search](#navigate-quickly-through-the-app-using-keyboard-shortcuts-and-search)
 
 
@@ -115,6 +116,11 @@ Below are a few features we have implemented to date:
       <img src="./packages/twenty-docs/static/img/create-tasks-light.png" alt="Tasks" />
     </picture>
 </p>
+
+## AI-driven lead scoring & insights
+
+Automatically rank leads and identify at-risk deals using built-in machine learning models.
+
 
 ## Navigate quickly through the app using keyboard shortcuts and search:
 

--- a/packages/twenty-server/src/modules/lead-scoring/lead-scoring.module.ts
+++ b/packages/twenty-server/src/modules/lead-scoring/lead-scoring.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { LeadScoringService } from './services/lead-scoring.service';
+
+@Module({
+  providers: [LeadScoringService],
+  exports: [LeadScoringService],
+})
+export class LeadScoringModule {}

--- a/packages/twenty-server/src/modules/lead-scoring/services/lead-scoring.service.spec.ts
+++ b/packages/twenty-server/src/modules/lead-scoring/services/lead-scoring.service.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeadScoringService } from './lead-scoring.service';
+
+// Mock current date to keep tests deterministic
+const RealDate = Date;
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-01T00:00:00Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe('LeadScoringService', () => {
+  let service: LeadScoringService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LeadScoringService],
+    }).compile();
+
+    service = module.get<LeadScoringService>(LeadScoringService);
+  });
+
+  it('calculates high score for promising deal', () => {
+    const score = service.calculateLeadScore({
+      amount: { amountMicros: 50000000, currencyCode: 'USD' },
+      stage: 'PROPOSAL',
+      closeDate: new Date('2023-01-05T00:00:00Z'),
+    } as any);
+
+    expect(score).toBeGreaterThan(0.5);
+  });
+
+  it('detects at-risk deal', () => {
+    const risk = service.isDealAtRisk({
+      amount: { amountMicros: 1000000, currencyCode: 'USD' },
+      stage: 'NEW',
+      closeDate: new Date('2022-12-20T00:00:00Z'),
+    } as any);
+
+    expect(risk).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/modules/lead-scoring/services/lead-scoring.service.ts
+++ b/packages/twenty-server/src/modules/lead-scoring/services/lead-scoring.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { OpportunityWorkspaceEntity } from 'src/modules/opportunity/standard-objects/opportunity.workspace-entity';
+
+/**
+ * Service providing basic machine learning driven lead scoring and risk insights.
+ * The scoring uses a simple logistic regression over opportunity fields.
+ */
+@Injectable()
+export class LeadScoringService {
+  /**
+   * Calculate a score between 0 and 1 estimating how likely the lead will close.
+   * Higher scores indicate a better chance of closing.
+   */
+  calculateLeadScore(opportunity: Pick<OpportunityWorkspaceEntity, 'amount' | 'stage' | 'closeDate'>): number {
+    const stageWeights: Record<string, number> = {
+      NEW: 0,
+      SCREENING: 0.2,
+      MEETING: 0.4,
+      PROPOSAL: 0.7,
+      CUSTOMER: 1,
+    };
+
+    const w0 = -1;
+    const wAmount = 0.000001; // amountMicros is used
+    const wStage = 1;
+    const wTime = -0.01;
+
+    const amount = opportunity.amount ? opportunity.amount.amountMicros : 0;
+    const stageWeight = stageWeights[opportunity.stage] ?? 0;
+    const daysUntilClose = opportunity.closeDate
+      ? (opportunity.closeDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+      : 0;
+
+    const x = w0 + wAmount * amount + wStage * stageWeight + wTime * daysUntilClose;
+    const score = 1 / (1 + Math.exp(-x));
+    return parseFloat(score.toFixed(4));
+  }
+
+  /**
+   * Determine if a deal is at risk based on the calculated score.
+   * Deals with a score under 0.4 are considered at risk.
+   */
+  isDealAtRisk(opportunity: Pick<OpportunityWorkspaceEntity, 'amount' | 'stage' | 'closeDate'>): boolean {
+    const score = this.calculateLeadScore(opportunity);
+    return score < 0.4;
+  }
+}

--- a/packages/twenty-server/src/modules/modules.module.ts
+++ b/packages/twenty-server/src/modules/modules.module.ts
@@ -7,6 +7,7 @@ import { FavoriteModule } from 'src/modules/favorite/favorite.module';
 import { MessagingModule } from 'src/modules/messaging/messaging.module';
 import { ViewModule } from 'src/modules/view/view.module';
 import { WorkflowModule } from 'src/modules/workflow/workflow.module';
+import { LeadScoringModule } from 'src/modules/lead-scoring/lead-scoring.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     WorkflowModule,
     FavoriteFolderModule,
     FavoriteModule,
+    LeadScoringModule,
   ],
   providers: [],
   exports: [],


### PR DESCRIPTION
## Summary
- add AI-driven lead scoring service
- integrate module with server modules
- document feature in README
- add unit tests for scoring service

## Testing
- `npx nx test twenty-server` *(fails: npm 403 forbidden)*
- `yarn nx test twenty-server` *(fails: corepack fetch error)*

------
https://chatgpt.com/codex/tasks/task_e_68446ebd1d58832f9962441b7f54e1d1