### PR TITLE
Add workflow notification action

### DIFF
--- a/packages/twenty-server/src/modules/notification/__tests__/notification.service.spec.ts
+++ b/packages/twenty-server/src/modules/notification/__tests__/notification.service.spec.ts
@@ -1,0 +1,9 @@
+import { NotificationService } from '../notification.service';
+
+describe('NotificationService', () => {
+  it('stores sent notifications', () => {
+    const service = new NotificationService();
+    service.sendNotification('user1', 'hello');
+    expect(service.getNotifications()).toEqual([{ to: 'user1', message: 'hello' }]);
+  });
+});

--- a/packages/twenty-server/src/modules/notification/notification.module.ts
+++ b/packages/twenty-server/src/modules/notification/notification.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+
+@Global()
+@Module({
+  providers: [NotificationService],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/packages/twenty-server/src/modules/notification/notification.service.ts
+++ b/packages/twenty-server/src/modules/notification/notification.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NotificationService {
+  private readonly notifications: { to: string; message: string }[] = [];
+
+  sendNotification(to: string, message: string) {
+    this.notifications.push({ to, message });
+    // In real implementation, push to user notification center
+    console.log(`Notify ${to}: ${message}`);
+  }
+
+  getNotifications() {
+    return this.notifications;
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/factories/workflow-executor.factory.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/factories/workflow-executor.factory.ts
@@ -10,6 +10,7 @@ import { CodeWorkflowAction } from 'src/modules/workflow/workflow-executor/workf
 import { FilterWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/filter.workflow-action';
 import { FormWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/form/form.workflow-action';
 import { SendEmailWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action';
+import { SendNotificationWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification.workflow-action';
 import { CreateRecordWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action';
 import { DeleteRecordWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/delete-record.workflow-action';
 import { FindRecordsWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action';
@@ -21,6 +22,7 @@ export class WorkflowExecutorFactory {
   constructor(
     private readonly codeWorkflowAction: CodeWorkflowAction,
     private readonly sendEmailWorkflowAction: SendEmailWorkflowAction,
+    private readonly sendNotificationWorkflowAction: SendNotificationWorkflowAction,
     private readonly createRecordWorkflowAction: CreateRecordWorkflowAction,
     private readonly updateRecordWorkflowAction: UpdateRecordWorkflowAction,
     private readonly deleteRecordWorkflowAction: DeleteRecordWorkflowAction,
@@ -35,6 +37,8 @@ export class WorkflowExecutorFactory {
         return this.codeWorkflowAction;
       case WorkflowActionType.SEND_EMAIL:
         return this.sendEmailWorkflowAction;
+      case WorkflowActionType.SEND_NOTIFICATION:
+        return this.sendNotificationWorkflowAction;
       case WorkflowActionType.CREATE_RECORD:
         return this.createRecordWorkflowAction;
       case WorkflowActionType.UPDATE_RECORD:

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/guards/is-workflow-send-notification-action.guard.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/guards/is-workflow-send-notification-action.guard.ts
@@ -1,0 +1,11 @@
+import {
+  WorkflowAction,
+  WorkflowActionType,
+  WorkflowSendNotificationAction,
+} from '../../types/workflow-action.type';
+
+export const isWorkflowSendNotificationAction = (
+  action: WorkflowAction,
+): action is WorkflowSendNotificationAction => {
+  return action.type === WorkflowActionType.SEND_NOTIFICATION;
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification-action.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification-action.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { NotificationModule } from 'src/modules/notification/notification.module';
+import { SendNotificationWorkflowAction } from './send-notification.workflow-action';
+
+@Module({
+  imports: [NotificationModule],
+  providers: [SendNotificationWorkflowAction],
+  exports: [SendNotificationWorkflowAction],
+})
+export class SendNotificationActionModule {}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification.workflow-action.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+
+import { NotificationService } from 'src/modules/notification/notification.service';
+import { WorkflowExecutor } from '../../interfaces/workflow-executor.interface';
+import {
+  WorkflowStepExecutorException,
+  WorkflowStepExecutorExceptionCode,
+} from '../../exceptions/workflow-step-executor.exception';
+import { WorkflowExecutorInput } from '../../types/workflow-executor-input';
+import { WorkflowExecutorOutput } from '../../types/workflow-executor-output.type';
+import { resolveInput } from '../../utils/variable-resolver.util';
+import { isWorkflowSendNotificationAction } from './guards/is-workflow-send-notification-action.guard';
+import { WorkflowSendNotificationActionInput } from './types/workflow-send-notification-action-input.type';
+
+export type WorkflowSendNotificationStepOutputSchema = {
+  success: boolean;
+};
+
+@Injectable()
+export class SendNotificationWorkflowAction implements WorkflowExecutor {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  async execute({ currentStepId, steps, context }: WorkflowExecutorInput): Promise<WorkflowExecutorOutput> {
+    const step = steps.find((s) => s.id === currentStepId);
+
+    if (!step) {
+      throw new WorkflowStepExecutorException(
+        'Step not found',
+        WorkflowStepExecutorExceptionCode.STEP_NOT_FOUND,
+      );
+    }
+
+    if (!isWorkflowSendNotificationAction(step)) {
+      throw new WorkflowStepExecutorException(
+        'Step is not a send notification action',
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+      );
+    }
+
+    const input = resolveInput(step.settings.input, context) as WorkflowSendNotificationActionInput;
+
+    const schema = z.object({ userId: z.string().uuid(), message: z.string() });
+    const result = schema.safeParse(input);
+    if (!result.success) {
+      throw new WorkflowStepExecutorException(
+        'Invalid notification input',
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+      );
+    }
+
+    this.notificationService.sendNotification(input.userId, input.message);
+
+    return { result: { success: true } as WorkflowSendNotificationStepOutputSchema };
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-input.type.ts
@@ -1,0 +1,4 @@
+export type WorkflowSendNotificationActionInput = {
+  userId: string;
+  message: string;
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-settings.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-settings.type.ts
@@ -1,0 +1,6 @@
+import { WorkflowSendNotificationActionInput } from './workflow-send-notification-action-input.type';
+import { BaseWorkflowActionSettings } from '../../types/workflow-action-settings.type';
+
+export type WorkflowSendNotificationActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowSendNotificationActionInput;
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type.ts
@@ -3,6 +3,7 @@ import { WorkflowCodeActionSettings } from 'src/modules/workflow/workflow-execut
 import { WorkflowFilterActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/types/workflow-filter-action-settings.type';
 import { WorkflowFormActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/form/types/workflow-form-action-settings.type';
 import { WorkflowSendEmailActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/types/workflow-send-email-action-settings.type';
+import { WorkflowSendNotificationActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-settings.type';
 import {
   WorkflowCreateRecordActionSettings,
   WorkflowDeleteRecordActionSettings,
@@ -24,6 +25,7 @@ export type BaseWorkflowActionSettings = {
 
 export type WorkflowActionSettings =
   | WorkflowSendEmailActionSettings
+  | WorkflowSendNotificationActionSettings
   | WorkflowCodeActionSettings
   | WorkflowCreateRecordActionSettings
   | WorkflowUpdateRecordActionSettings

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type.ts
@@ -2,6 +2,7 @@ import { WorkflowCodeActionSettings } from 'src/modules/workflow/workflow-execut
 import { WorkflowFilterActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/types/workflow-filter-action-settings.type';
 import { WorkflowFormActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/form/types/workflow-form-action-settings.type';
 import { WorkflowSendEmailActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/types/workflow-send-email-action-settings.type';
+import { WorkflowSendNotificationActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/notification/types/workflow-send-notification-action-settings.type';
 import {
   WorkflowCreateRecordActionSettings,
   WorkflowDeleteRecordActionSettings,
@@ -13,6 +14,7 @@ import { WorkflowActionSettings } from 'src/modules/workflow/workflow-executor/w
 export enum WorkflowActionType {
   CODE = 'CODE',
   SEND_EMAIL = 'SEND_EMAIL',
+  SEND_NOTIFICATION = 'SEND_NOTIFICATION',
   CREATE_RECORD = 'CREATE_RECORD',
   UPDATE_RECORD = 'UPDATE_RECORD',
   DELETE_RECORD = 'DELETE_RECORD',
@@ -38,6 +40,11 @@ export type WorkflowCodeAction = BaseWorkflowAction & {
 export type WorkflowSendEmailAction = BaseWorkflowAction & {
   type: WorkflowActionType.SEND_EMAIL;
   settings: WorkflowSendEmailActionSettings;
+};
+
+export type WorkflowSendNotificationAction = BaseWorkflowAction & {
+  type: WorkflowActionType.SEND_NOTIFICATION;
+  settings: WorkflowSendNotificationActionSettings;
 };
 
 export type WorkflowCreateRecordAction = BaseWorkflowAction & {
@@ -73,6 +80,7 @@ export type WorkflowFilterAction = BaseWorkflowAction & {
 export type WorkflowAction =
   | WorkflowCodeAction
   | WorkflowSendEmailAction
+  | WorkflowSendNotificationAction
   | WorkflowCreateRecordAction
   | WorkflowUpdateRecordAction
   | WorkflowDeleteRecordAction

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-executor.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-executor.module.ts
@@ -8,6 +8,7 @@ import { CodeActionModule } from 'src/modules/workflow/workflow-executor/workflo
 import { FilterActionModule } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/filter-action.module';
 import { FormActionModule } from 'src/modules/workflow/workflow-executor/workflow-actions/form/form-action.module';
 import { SendEmailActionModule } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email-action.module';
+import { SendNotificationActionModule } from 'src/modules/workflow/workflow-executor/workflow-actions/notification/send-notification-action.module';
 import { RecordCRUDActionModule } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud-action.module';
 import { WorkflowExecutorWorkspaceService } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 import { WorkflowRunModule } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.module';
@@ -17,6 +18,7 @@ import { WorkflowRunModule } from 'src/modules/workflow/workflow-runner/workflow
     WorkflowCommonModule,
     CodeActionModule,
     SendEmailActionModule,
+    SendNotificationActionModule,
     RecordCRUDActionModule,
     FormActionModule,
     WorkflowRunModule,


### PR DESCRIPTION
## Summary
- add Notification service and module
- create `SEND_NOTIFICATION` workflow action for automation rules
- wire notification action into workflow executor factory and module
- cover new notification service with unit test

## Testing
- `npx nx test twenty-server` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68446edd3930832f915278f40787c9e5