### PR TITLE
Add multi-channel communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Below are a few features we have implemented to date:
 + [See rich notes tasks displayed in a timeline](#see-rich-notes-tasks-displayed-in-a-timeline)
 + [Create tasks on records](#create-tasks-on-records)
 + [Navigate quickly through the app using keyboard shortcuts and search](#navigate-quickly-through-the-app-using-keyboard-shortcuts-and-search)
++ [Engage across channels with multi-channel communication](#track-deals-effortlessly-with-multi-channel-communication)
 
 
 ## Add, filter, sort, edit, and track customers:
@@ -76,7 +77,7 @@ Below are a few features we have implemented to date:
     </picture>
 </p>
 
-## Track deals effortlessly with the email integration:
+## Track deals effortlessly with multi-channel communication:
 
 <p align="center">
     <picture>

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
@@ -20,6 +20,7 @@ export type CreateMessageChannelInput = {
   workspaceId: string;
   connectedAccountId: string;
   handle: string;
+  type?: MessageChannelType;
   messageVisibility?: MessageChannelVisibility;
   manager: WorkspaceEntityManager;
 };
@@ -40,6 +41,7 @@ export class CreateMessageChannelService {
       workspaceId,
       connectedAccountId,
       handle,
+      type = MessageChannelType.EMAIL,
       messageVisibility,
       manager,
     } = input;
@@ -54,7 +56,7 @@ export class CreateMessageChannelService {
       {
         id: v4(),
         connectedAccountId,
-        type: MessageChannelType.EMAIL,
+        type,
         handle,
         visibility:
           messageVisibility || MessageChannelVisibility.SHARE_EVERYTHING,

--- a/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
@@ -48,6 +48,8 @@ export enum MessageChannelVisibility {
 export enum MessageChannelType {
   EMAIL = 'email',
   SMS = 'sms',
+  PHONE_CALL = 'phone_call',
+  LIVE_CHAT = 'live_chat',
 }
 
 export enum MessageChannelContactAutoCreationPolicy {
@@ -145,6 +147,18 @@ export class MessageChannelWorkspaceEntity extends BaseWorkspaceEntity {
         label: 'SMS',
         position: 1,
         color: 'blue',
+      },
+      {
+        value: MessageChannelType.PHONE_CALL,
+        label: 'Phone Call',
+        position: 2,
+        color: 'orange',
+      },
+      {
+        value: MessageChannelType.LIVE_CHAT,
+        label: 'Live Chat',
+        position: 3,
+        color: 'purple',
       },
     ],
     defaultValue: `'${MessageChannelType.EMAIL}'`,


### PR DESCRIPTION
## Summary
- extend `MessageChannelType` enum with Phone Call and Live Chat options
- allow specifying the channel type when creating a message channel
- list multi-channel communication as a feature in README
- update README heading about communication

## Testing
- `npx nx lint twenty-server` *(fails: 403 Forbidden)*
- `npx nx test twenty-server` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68446eed59c8832f870eb930daaf605f